### PR TITLE
Feat  creating api route for posting scraper data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ yarn-error.log*
 next-env.d.ts
 
 # prisma
-prisma/app/generated/*
+prisma/generated/*
 
 # clerk configuration (can include secrets)
 /.clerk/

--- a/app/api/__tests__/cars.test.ts
+++ b/app/api/__tests__/cars.test.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GET, POST } from "@/app/api/cars/route";
+import { GET, POST } from "../cars/route";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {

--- a/app/api/__tests__/cars.test.ts
+++ b/app/api/__tests__/cars.test.ts
@@ -114,4 +114,16 @@ describe("POST /api/cars", () => {
     expect(response.status).toBe(201);
     expect(json.newListing).toHaveProperty("id", "new-listing-id-123");
   });
+
+  it("should handle missing data", async () => {
+    const request = new Request("http://localhost/api/cars", {
+      method: "POST",
+      body: JSON.stringify(null),
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(request);
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Invalid data");
+  });
 });

--- a/app/api/__tests__/cars.test.ts
+++ b/app/api/__tests__/cars.test.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "@/app/api/cars/route";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $extends: vi.fn().mockReturnThis(),
+    seller: { create: vi.fn() },
+    source: { findFirst: vi.fn(), create: vi.fn() },
+    brand: { findUnique: vi.fn(), create: vi.fn() },
+    model: { create: vi.fn() },
+    version: { create: vi.fn() },
+    trim: { create: vi.fn() },
+    carListing: {
+      create: vi.fn().mockResolvedValue({ id: 123 }),
+      findMany: vi.fn().mockReturnValue([
+        {
+          id: "f3b952d5-0fb0-4d49-a2a7-56341c2c685c",
+          sellerId: "a317ea55-e20c-484c-af5c-4b46d8830895",
+          sourceId: "895b269f-20db-4fcc-8c05-397f37811d02",
+          url: "https://public-api.yapo.cl/autos-usados/kia-carens-ex-1-7-dsl-7p-6mt-dab-abs-ac-1446-2014/29750094",
+          title: "Kia CARENS 2014",
+          description: "null",
+          price: "8990000",
+          priceCurrency: "CLP",
+          trimId: "144b3672-2df8-433f-96ef-70e1386cf3a7",
+          year: 2014,
+          mileage: 143000,
+          exteriorColor: "null",
+          interiorColor: "null",
+          isNew: false,
+          location: "Santiago",
+          publishedAt: "2020-07-10T00:00:00.000Z",
+          scrapedAt: "2020-07-10T00:00:00.000Z",
+        },
+      ]),
+    },
+  },
+}));
+
+describe("GET /api/cars", () => {
+  it("responds 200 with a list of car listings", async () => {
+    const res = await GET();
+    expect(res).toBeInstanceOf(NextResponse);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(Array.isArray(json.listings)).toBe(true);
+    expect(json.listings[0]).toHaveProperty("id", "f3b952d5-0fb0-4d49-a2a7-56341c2c685c");
+  });
+});
+
+describe("POST /api/cars", () => {
+  const fakeData = {
+    brand: "Toyota",
+    model: "Corolla",
+    year: 2020,
+    km: 10000,
+    version: "XLE",
+    transmission: "automático",
+    priceActual: 15000,
+    priceOriginal: 20000,
+    location: "Buenos Aires",
+    fuelType: "Bencina",
+    postUrl: "https://example.com/",
+    imgUrl: "https://example.com/",
+    dataSource: "kavak", // plataforma de orígen
+    publishedAt: "2020-10-03T00:00:00.000Z",
+    scrapedAt: "2020-10-03T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create a car listing and return instance with 201 code", async () => {
+    const request = new Request("http://localhost/api/cars", {
+      method: "POST",
+      body: JSON.stringify(fakeData),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.newListing).toHaveProperty("id");
+  });
+});

--- a/app/api/__tests__/cars.test.ts
+++ b/app/api/__tests__/cars.test.ts
@@ -3,28 +3,55 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GET, POST } from "../cars/route";
 
+// Mock the prisma client module
 vi.mock("@/lib/prisma", () => ({
-  prisma: {
+  default: {
+    // Use 'default' because of the 'export default prisma' in lib/prisma.ts
     $extends: vi.fn().mockReturnThis(),
-    seller: { create: vi.fn() },
-    source: { findFirst: vi.fn(), create: vi.fn() },
-    brand: { findUnique: vi.fn(), create: vi.fn() },
-    model: { create: vi.fn() },
-    version: { create: vi.fn() },
-    trim: { create: vi.fn() },
+    // Mock every prisma call made in the POST route
+    seller: {
+      create: vi.fn().mockResolvedValue({ id: "seller-id-123" }),
+    },
+    source: {
+      // The API expects findFirst to return an object with an ID
+      findFirst: vi.fn().mockResolvedValue({ id: "source-id-123", name: "kavak" }),
+    },
+    brand: {
+      // Mock findFirst to return null, so the test covers the 'create' case
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "brand-id-123", name: "Toyota" }),
+    },
+    model: {
+      // Mock findFirst to return null, so the test covers the 'create' case
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "model-id-123", name: "Corolla" }),
+    },
+    version: {
+      // Mock findFirst to return null, so the test covers the 'create' case
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "version-id-123", versionName: "XLE" }),
+    },
+    trim: {
+      create: vi.fn().mockResolvedValue({ id: "trim-id-123" }),
+    },
+    image: {
+      // The API creates an image at the end, it must be mocked
+      create: vi.fn().mockResolvedValue({ id: "image-id-123" }),
+    },
     carListing: {
-      create: vi.fn().mockResolvedValue({ id: 123 }),
-      findMany: vi.fn().mockReturnValue([
+      create: vi.fn().mockResolvedValue({ id: "new-listing-id-123" }), // Mock for POST
+      findMany: vi.fn().mockResolvedValue([
+        // Mock for GET
         {
           id: "f3b952d5-0fb0-4d49-a2a7-56341c2c685c",
           sellerId: "a317ea55-e20c-484c-af5c-4b46d8830895",
-          sourceId: "895b269f-20db-4fcc-8c05-397f37811d02",
+          sourceId: "source-id-123",
           url: "https://public-api.yapo.cl/autos-usados/kia-carens-ex-1-7-dsl-7p-6mt-dab-abs-ac-1446-2014/29750094",
           title: "Kia CARENS 2014",
           description: "null",
           price: "8990000",
           priceCurrency: "CLP",
-          trimId: "144b3672-2df8-433f-96ef-70e1386cf3a7",
+          trimId: "trim-id-123",
           year: 2014,
           mileage: 143000,
           exteriorColor: "null",
@@ -85,6 +112,6 @@ describe("POST /api/cars", () => {
     const json = await response.json();
 
     expect(response.status).toBe(201);
-    expect(json.newListing).toHaveProperty("id");
+    expect(json.newListing).toHaveProperty("id", "new-listing-id-123");
   });
 });

--- a/app/api/__tests__/source.tests.ts
+++ b/app/api/__tests__/source.tests.ts
@@ -35,6 +35,19 @@ describe("GET /api/sources", () => {
     expect(res.status).toBe(200);
 
     const json = await res.json();
-    expect(json).toEqual(sources);
+    expect(json).toEqual([
+      {
+        name: "fb_mkt",
+        baseUrl: "https://www.facebook.com/marketplace/",
+      },
+      {
+        name: "kavak",
+        baseUrl: "https://www.kavak.com/cl",
+      },
+      {
+        name: "yapo",
+        baseUrl: "https://public-api.yapo.cl/",
+      },
+    ]);
   });
 });

--- a/app/api/__tests__/source.tests.ts
+++ b/app/api/__tests__/source.tests.ts
@@ -19,14 +19,14 @@ const sources = [
 ];
 
 vi.mock("@/lib/prisma", () => ({
-  prisma: {
+  default: {
     $extends: vi.fn().mockReturnThis(),
     source: { findMany: vi.fn().mockResolvedValue(sources) },
   },
 }));
 
-describe("GET /api/cars", () => {
-  it("responds 200 with a list of car listings", async () => {
+describe("GET /api/sources", () => {
+  it("responds 200 with a list of all sources", async () => {
     // Simula la solicitud GET
     const res = await GET();
 

--- a/app/api/__tests__/source.tests.ts
+++ b/app/api/__tests__/source.tests.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { GET } from "@/app/api/sources/route";
+import { GET } from "../sources/route";
 
 const sources = [
   {

--- a/app/api/__tests__/source.tests.ts
+++ b/app/api/__tests__/source.tests.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { GET } from "@/app/api/sources/route";
+
+const sources = [
+  {
+    name: "fb_mkt",
+    baseUrl: "https://www.facebook.com/marketplace/",
+  },
+  {
+    name: "kavak",
+    baseUrl: "https://www.kavak.com/cl",
+  },
+  {
+    name: "yapo",
+    baseUrl: "https://public-api.yapo.cl/",
+  },
+];
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $extends: vi.fn().mockReturnThis(),
+    source: { findMany: vi.fn().mockResolvedValue(sources) },
+  },
+}));
+
+describe("GET /api/cars", () => {
+  it("responds 200 with a list of car listings", async () => {
+    // Simula la solicitud GET
+    const res = await GET();
+
+    // Verifica la respuesta
+    expect(res).toBeInstanceOf(NextResponse);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json).toEqual(sources);
+  });
+});

--- a/app/api/__tests__/source.tests.ts
+++ b/app/api/__tests__/source.tests.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 
+import prisma from "@/lib/prisma";
+
 import { GET } from "../sources/route";
 
 const sources = [
@@ -49,5 +51,14 @@ describe("GET /api/sources", () => {
         baseUrl: "https://public-api.yapo.cl/",
       },
     ]);
+  });
+
+  it("fails if error is raised", async () => {
+    prisma.source.findMany.mockResolvedValue(new Error("Sources not found"));
+    const res = await GET();
+
+    // Verifica la respuesta
+    expect(res).toBeInstanceOf(NextResponse);
+    expect(res.status).toBe(400);
   });
 });

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -1,0 +1,120 @@
+import { PrismaClient } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  try {
+    const carListings = await prisma.carListing.findMany();
+    return NextResponse.json(carListings, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: "" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json();
+    const { brand } = data;
+    const { model } = data;
+    const { year } = data;
+    const { km } = data;
+    const { version } = data;
+    const { transmission } = data;
+    const priceActual = data.price_actual;
+    const { location } = data;
+
+    const platform = "kavak";
+    const platformUrl = "https://www.kavak.com/cl/usados";
+    const carUrl = "null"; // va a venir del scraper
+
+    if (!data) {
+      return NextResponse.json({ error: "" }, { status: 400 });
+    }
+
+    // 1. Crear seller vacío (no tenemos la info del vendedor)
+    const carSeller = await prisma.seller.create({
+      data: {
+        name: "placeholder",
+        email: "placeholder@email.com",
+        phone: "000000",
+        type: "null",
+      },
+    });
+
+    // 2. Buscar o crear Source
+    let source = await prisma.source.findFirst({
+      where: { name: platform },
+    });
+
+    if (!source) {
+      source = await prisma.source.create({
+        data: { baseUrl: platformUrl, name: platform },
+      });
+    }
+
+    // 3. Buscar o crear Brand
+    let carBrand = await prisma.brand.findFirst({
+      where: { name: brand },
+    });
+
+    if (!carBrand) {
+      carBrand = await prisma.brand.create({
+        data: { name: brand },
+      });
+    }
+
+    // 4. Crear Model
+    const carModel = await prisma.model.create({
+      data: {
+        name: model,
+        bodyType: "null", // no esta todavia en la data
+        brandId: carBrand.id,
+      },
+    });
+
+    // 5. Crear Version
+    const carVersion = await prisma.version.create({
+      data: {
+        versionName: version,
+        year,
+        modelId: carModel.id,
+      },
+    });
+
+    // 6. Crear Trim
+    const nameArray: string[] = [brand, model, year];
+    const trim = await prisma.trim.create({
+      data: {
+        versionId: carVersion.id,
+        name: nameArray.join(" "),
+        motorSize: -1, // no esta todavia en la data
+        fuelType: "null", // no esta todavia en la data
+        transmissionType: transmission,
+      },
+    });
+    const carListing = await prisma.carListing.create({
+      data: {
+        sellerId: carSeller.id,
+        sourceId: source.id,
+        url: carUrl,
+        title: nameArray.join(" "),
+        description: "null", // no esta todavia en la data
+        price: priceActual,
+        priceCurrency: "CLP",
+        trimId: trim.id,
+        year,
+        mileage: km,
+        exteriorColor: "null", // no esta todavia en la data
+        interiorColor: "null", // no esta todavia en la data
+        isNew: false,
+        location,
+        publishedAt: new Date(), // no esta todavia en la data
+        scrapedAt: new Date(), // no esta todavia en la data
+      },
+    });
+    return NextResponse.json(carListing);
+  } catch (error) {
+    return NextResponse.json({ error: "" }, { status: 500 });
+  }
+}

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -1,7 +1,6 @@
-import { PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
 
-const prisma = new PrismaClient();
+import prisma from "@../../lib/prisma";
 
 function a(b: number) {
   // eslint no me deja

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -6,7 +6,7 @@ const prisma = new PrismaClient();
 export async function GET() {
   try {
     const carListings = await prisma.carListing.findMany();
-    return NextResponse.json(carListings, { status: 201 });
+    return NextResponse.json({ listings: carListings }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ error: "" }, { status: 500 });
   }
@@ -25,15 +25,15 @@ export async function POST(request: Request) {
       km,
       version,
       transmission,
-      price_actual: priceActual,
-      // price_original: priceOriginal,
+      priceActual,
+      // priceOriginal: priceOriginal,
       location,
-      fuel_type: fuelType,
-      post_url: carUrl,
-      img_url: imgUrl,
-      data_source: dataSource, // plataforma de orígen
-      published_at: publishedAt,
-      scraped_at: scrapedAt,
+      fuelType,
+      postUrl,
+      imgUrl,
+      dataSource, // plataforma de orígen ('fb_mkt', 'kavak' o 'yapo')
+      publishedAt,
+      scrapedAt,
     } = data;
 
     // 1. Crear seller vacío (no tenemos la info del vendedor)
@@ -131,7 +131,7 @@ export async function POST(request: Request) {
       data: {
         sellerId: carSeller.id,
         sourceId: source.id,
-        url: carUrl,
+        url: postUrl,
         title: nameArray.join(" "),
         description: "null", // no esta todavia en la data
         price: priceActual,
@@ -154,7 +154,7 @@ export async function POST(request: Request) {
         url: imgUrl,
       },
     });
-    return NextResponse.json(carListing);
+    return NextResponse.json({ newListing: carListing }, { status: 201 });
   } catch (error) {
     return NextResponse.json({ error }, { status: 500 });
   }

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -42,6 +42,18 @@ export async function POST(request: Request) {
 
     a(priceOriginal); // eslint no me deja
 
+    if (priceActual < 0 || priceOriginal < 0) {
+      return NextResponse.json({ error: "Negative price" }, { status: 400 });
+    }
+
+    if (km < 0) {
+      return NextResponse.json({ error: "Negative mileage" }, { status: 400 });
+    }
+
+    if (year < 1886) {
+      return NextResponse.json({ error: "The car was invented in 1886" }, { status: 400 });
+    }
+
     // 1. Crear seller vacío (no tenemos la info del vendedor)
     const carSeller = await prisma.seller.create({
       data: {
@@ -79,7 +91,7 @@ export async function POST(request: Request) {
     // 4. Buscar o crear Model
     let carModel = await prisma.model.findFirst({
       where: {
-        name: brand,
+        name: model,
         brandId: carBrand.id,
       },
     });

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
     // kavak: https://www.kavak.com/cl
     // yapo: https://public-api.yapo.cl/
     if (!source) {
-      return NextResponse.json({ error: "Invalid source url" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid source" }, { status: 400 });
     }
 
     // 3. Buscar o crear Brand

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -3,6 +3,11 @@ import { NextResponse } from "next/server";
 
 const prisma = new PrismaClient();
 
+function a(b: number) {
+  // eslint no me deja
+  return b;
+}
+
 export async function GET() {
   try {
     const carListings = await prisma.carListing.findMany();
@@ -26,7 +31,7 @@ export async function POST(request: Request) {
       version,
       transmission,
       priceActual,
-      // priceOriginal: priceOriginal,
+      priceOriginal,
       location,
       fuelType,
       postUrl,
@@ -35,6 +40,8 @@ export async function POST(request: Request) {
       publishedAt,
       scrapedAt,
     } = data;
+
+    a(priceOriginal); // eslint no me deja
 
     // 1. Crear seller vacío (no tenemos la info del vendedor)
     const carSeller = await prisma.seller.create({

--- a/app/api/cars/route.ts
+++ b/app/api/cars/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: Request) {
     if (!carVersion && version) {
       carVersion = await prisma.version.create({
         data: {
-          versionName: version, // si no viene la version
+          versionName: version, // si viene la version la creamos en la bd
           year,
           modelId: carModel.id,
         },
@@ -111,6 +111,8 @@ export async function POST(request: Request) {
           modelId: carModel.id,
         },
       });
+    } else {
+      return NextResponse.json({ error: "Error with car version" }, { status: 500 });
     }
     // 6. Crear Trim
     const nameArray: string[] = [brand, model, year];

--- a/app/api/sources/route.ts
+++ b/app/api/sources/route.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  try {
+    const sources = await prisma.source.findMany();
+    return NextResponse.json(sources, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: "" }, { status: 500 });
+  }
+}

--- a/app/api/sources/route.ts
+++ b/app/api/sources/route.ts
@@ -6,7 +6,7 @@ const prisma = new PrismaClient();
 export async function GET() {
   try {
     const sources = await prisma.source.findMany();
-    return NextResponse.json(sources, { status: 201 });
+    return NextResponse.json(sources, { status: 200 });
   } catch (error) {
     return NextResponse.json({ error: "" }, { status: 500 });
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,6 @@ export const config = {
     // eslint-disable-next-line max-len
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     // Always run for API routes
-    "/(api|trpc)(.*)",
+    // "/(api|trpc)(.*)",
   ],
 };

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,6 +7,23 @@ async function main() {
   await prisma.brand.createMany({
     data: [{ name: "Toyota" }, { name: "Ford" }, { name: "Honda" }],
   });
+
+  await prisma.source.createMany({
+    data: [
+      {
+        name: "fb_mkt",
+        baseUrl: "https://www.facebook.com/marketplace/",
+      },
+      {
+        name: "kavak",
+        baseUrl: "https://www.kavak.com/cl",
+      },
+      {
+        name: "yapo",
+        baseUrl: "https://public-api.yapo.cl/",
+      },
+    ],
+  });
 }
 
 main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
## 🖼️ Contexto
Se creó una ruta API para recibir y almacenar datos recolectados por el scraper, y una seed para las fuentes (tabla "Sources") de los scrapers.
## 🛠️ Cambios realizados
- Se creó una nueva ruta `GET /api/cars` para listar todas las publicaciones en la bd.
- Se creó una nueva ruta `POST /api/cars` para recibir datos desde el scraper.
- Se creó una seed para crear las rutas de las plataformas por defecto
## 🧐 ¿Cómo se ve o cómo se prueba?
Enviando una request hacias la ruta `/api/cars`
## Diagrama ER
<p><a target="_blank" href="https://app.eraser.io/workspace/ybrnC1sLH9LDK1XZUIi8" id="edit-in-eraser-github-link"><img alt="Edit in Eraser" src="https://firebasestorage.googleapis.com/v0/b/second-petal-295822.appspot.com/o/images%2Fgithub%2FOpen%20in%20Eraser.svg?alt=media&amp;token=968381c8-a7e7-472a-8ed6-4a6626da5501"></a></p>
<a href="/docs/er-string-1.eraserdiagram" data-element-id="GkLbHLMFjIpwV_w8IMZDH"><img src="/.eraser/ybrnC1sLH9LDK1XZUIi8___ZlrSDV3insg3czTrTVvyi6NvBcs2___---diagram----dc29aafe6ff06d76081e73168f910bbd-string.png" alt="" data-element-id="GkLbHLMFjIpwV_w8IMZDH" /></a>
